### PR TITLE
Fix start transaction in mysqli driver

### DIFF
--- a/lib/DbSimple/Database.php
+++ b/lib/DbSimple/Database.php
@@ -236,10 +236,13 @@ abstract class DbSimple_Database extends DbSimple_LastError
      */
     public function escape($s, $isIdent=false)
     {
-        if(is_float($s)) {
+        if(is_int($s)) {
+        // if this is a integer value - not need to escape (as for ?d placeholder)
+            return $s;
+        } elseif(is_float($s)) {
         // for mysql the point "." is the separator for the decimal point
         // for example, as for "?f" placeholder
-            $s = str_replace(',', '.', $s);
+            return str_replace(',', '.', $s);
         }
     
         return $this->_performEscape($s, $isIdent);

--- a/lib/DbSimple/Database.php
+++ b/lib/DbSimple/Database.php
@@ -236,6 +236,12 @@ abstract class DbSimple_Database extends DbSimple_LastError
      */
     public function escape($s, $isIdent=false)
     {
+        if(is_float($s)) {
+        // for mysql the point "." is the separator for the decimal point
+        // for example, as for "?f" placeholder
+            $s = str_replace(',', '.', $s);
+        }
+    
         return $this->_performEscape($s, $isIdent);
     }
 

--- a/lib/DbSimple/Database.php
+++ b/lib/DbSimple/Database.php
@@ -244,7 +244,7 @@ abstract class DbSimple_Database extends DbSimple_LastError
         // for example, as for "?f" placeholder
             return str_replace(',', '.', $s);
         }
-    
+
         return $this->_performEscape($s, $isIdent);
     }
 
@@ -725,7 +725,7 @@ abstract class DbSimple_Database extends DbSimple_LastError
                 # Placeholder
                 (\?) ( [_dsafn&|\#]? )                           #2 #3
             )
-        }sx';
+        }sxS';
         $query = preg_replace_callback(
             $re,
             array(&$this, '_expandPlaceholdersCallback'),

--- a/lib/DbSimple/Mysqli.php
+++ b/lib/DbSimple/Mysqli.php
@@ -116,7 +116,11 @@ class DbSimple_Mysqli extends DbSimple_Database
 
     protected function _performTransaction($parameters=null)
     {
-        return mysqli_begin_transaction($this->link);
+        if( function_exists('mysqli_begin_transaction') ) {
+            return mysqli_begin_transaction($this->link);
+        } else {
+            return mysqli_autocommit($this->link, false);
+        }
     }
 
 


### PR DESCRIPTION
1) Function mysqli_begin_transaction not exists in php version < 5.5.0 .
Then need use mysqli_autocommit


2) And bug with escape float value.


Например, если мы хотим сделать запрос вроде
$DB->query(
   ‘UPDATE `table`
   SET ?a
   WHERE `id` = ?d’,
  array(
     ‘key’ => 0.99,
  ),
  1
);

То должен быть сгенерирован SQL:
UPDATE `table` SET `key` = 0.99 WHERE `id` = 1;

Но библиотека генерирует неправильно, с запятой:
UPDATE `table` SET `key` = 0,99 WHERE `id` = 1;

 3) Добавил аналогичную обработку для integer значении.
Если в массиве передано значение типа integer, но его не нужно экранировать