### PR TITLE
Исправление php docs + поддержка плейсхолдера ?r (вставка raw аргумента)

### DIFF
--- a/lib/DbSimple/Connect.php
+++ b/lib/DbSimple/Connect.php
@@ -17,24 +17,20 @@ define('DBSIMPLE_PARENT_KEY', 'PARENT_KEY'); // forrest-based resultset support
  * <br>нужен для ленивой инициализации коннекта к базе
  *
  * @package DbSimple
- * @method mixed transaction(string $mode=null)
- * @method mixed commit()
- * @method mixed rollback()
- * @method mixed select(string $query [, $arg1] [,$arg2] ...)
- * @method mixed selectRow(string $query [, $arg1] [,$arg2] ...)
- * @method array selectCol(string $query [, $arg1] [,$arg2] ...)
- * @method string selectCell(string $query [, $arg1] [,$arg2] ...)
- * @method mixed query(string $query [, $arg1] [,$arg2] ...)
+ * @method mixed transaction(string $mode=null) - см. DbSimple_Database::transaction()
+ * @method mixed commit() - см. DbSimple_Database::commit()
+ * @method mixed rollback() - см. DbSimple_Database::rollback()
+ * @method mixed select(string $query) - см. DbSimple_Database::select()
+ * @method mixed selectRow() - см. DbSimple_Database::selectRow()
+ * @method array selectCol() - см. DbSimple_Database::selectCol()
+ * @method string selectCell() - см. DbSimple_Database::selectCell()
+ * @method mixed query() - см. DbSimple_Database::query()
  * @method string escape(mixed $s, bool $isIdent=false)
- * @method DbSimple_SubQuery subquery(string $query [, $arg1] [,$arg2] ...)
- * @method callback setLogger(callback $logger)
- * @method callback setCacher(callback $cacher)
- * @method string setIdentPrefix($prx)
- * @method string setCachePrefix($prx)
+ * @method DbSimple_SubQuery subquery()
  */
 class DbSimple_Connect
 {
-	/** @var DbSimple_Generic_Database База данных */
+	/** @var DbSimple_Database База данных */
 	protected $DbSimple;
 	/** @var string DSN подключения */
 	protected $DSN;

--- a/lib/DbSimple/Database.php
+++ b/lib/DbSimple/Database.php
@@ -331,7 +331,7 @@ abstract class DbSimple_Database extends DbSimple_LastError
      * массив поле=>значение для этой строки
      *
      * @param string $name имя класса
-     * @return DbSimple_Generic_Database указатель на себя
+     * @return DbSimple_Database указатель на себя
      */
     public function setClassName($name)
     {
@@ -1239,7 +1239,7 @@ interface DbSimple_Blob
 
 /**
  * Класс для хранения подзапроса - результата выполнения функции
- * DbSimple_Generic_Database::subquery
+ * DbSimple_Database::subquery
  *
  */
 class DbSimple_SubQuery

--- a/lib/DbSimple/Database.php
+++ b/lib/DbSimple/Database.php
@@ -717,13 +717,13 @@ abstract class DbSimple_Database extends DbSimple_LastError
                 # Optional blocks
                 \{
                     # Use "+" here, not "*"! Else nested blocks are not processed well.
-                    ( (?> (?>(\??)[^{}]+)  |  (?R) )* )             #1
+                    ( (?> (?>(\??)[^{}]+)  |  (?R) )* )             #1 #2
                 \}
             )
               |
             (?>
                 # Placeholder
-                (\?) ( [_dsafn&|\#]? )                           #2 #3
+                (\?) ( [_dsafnr&|\#]? )                           #3 #4
             )
         }sxS';
         $query = preg_replace_callback(
@@ -741,8 +741,14 @@ abstract class DbSimple_Database extends DbSimple_LastError
     );
 
     /**
-     * string _expandPlaceholdersCallback(list $m)
      * Internal function to replace placeholders (see preg_replace_callback).
+     * @param array $m
+     *         $m[0] - the whole regex match
+     *         $m[1] - if set, the whole optional block, without {outer curly brackets}
+     *         $m[2] - if set, the "?" sign for the optional block
+     *         $m[3] - if set, the "?" sign for non-optional block
+     *         $m[4] - if set, the placeholder type for the non-optional block, one of the following letters: _dsafnr&|#
+     * @return mixed
      */
     private function _expandPlaceholdersCallback($m)
     {
@@ -839,6 +845,8 @@ abstract class DbSimple_Database extends DbSimple_LastError
                 case 'n':
                     // NULL-based placeholder.
                     return empty($value)? 'NULL' : intval($value);
+				case 'r':
+					return $value;
             }
 
             // Native arguments are not processed.

--- a/lib/DbSimple/Database.php
+++ b/lib/DbSimple/Database.php
@@ -845,8 +845,8 @@ abstract class DbSimple_Database extends DbSimple_LastError
                 case 'n':
                     // NULL-based placeholder.
                     return empty($value)? 'NULL' : intval($value);
-				case 'r':
-					return $value;
+                case 'r':
+                    return $value;
             }
 
             // Native arguments are not processed.

--- a/lib/DbSimple/Generic.php
+++ b/lib/DbSimple/Generic.php
@@ -33,7 +33,7 @@
  *
  * Contains 3 classes:
  * - DbSimple_Generic: database factory class
- * - DbSimple_Generic_Database: common database methods
+ * - DbSimple_Database: common database methods
  * - DbSimple_Generic_Blob: common BLOB support
  * - DbSimple_Generic_LastError: error reporting and tracking
  *


### PR DESCRIPTION
PhpStorm подсветил ошибки в phpdocs:
- Неверное название класса DbSimple_Generic_Database (на самом деле DbSimple_Database).
- В классе DbSimple_Connect теги @method, которых не должно быть, т.к. эти методы объявлены в самом классе.

Плюс добавил полезный плейсхолдер "?r" - бывает удобно вставить кусок SQL параметром (например, в рантайме решить LEFT или INNER джоин делать).
